### PR TITLE
block ui on exporting and fixed xls handler when no filter and hidden…

### DIFF
--- a/rd_ui/app/views/dashboard.html
+++ b/rd_ui/app/views/dashboard.html
@@ -14,22 +14,24 @@
                 <button type="button" class="btn btn-default btn-xs" data-toggle="modal"
                         href="#add_query_dialog" tooltip="Add Widget (Chart/Table/Pivot)"><span class="glyphicon glyphicon-plus"></span>
                 </button>
-                <butotn class="btn btn-danger btn-xs" ng-click="archiveDashboard()" ng-if="!dashboard.is_archived" tooltip="Archive"><i class="fa fa-archive"></i></butotn>
+                <button class="btn btn-danger btn-xs" ng-click="archiveDashboard()" ng-if="!dashboard.is_archived" tooltip="Archive"><i class="fa fa-archive"></i></button>
             </div>
         </span>
-        <button style="float: right; font-weight: bold" type="button" class="btn btn-default" title="Collapse all widgets." ng-click="changeCollapseValues(true)">
-            Collapse 
+        <button style="float: right;" type="button" class="btn btn-default" title="Collapse all widgets." ng-click="changeCollapseValues(true)">
+            Collapse
         </button>
-        <button style="float: right; font-weight: bold; margin-right: 5px;" type="button" class="btn btn-default" title="Expand all widgets." ng-click="changeCollapseValues(false)">
-            Expand 
+        <button style="float: right; margin-right: 5px;" type="button" class="btn btn-default" title="Expand all widgets." ng-click="changeCollapseValues(false)">
+            Expand
         </button>
-        <button style="float: right; margin-right: 5px;" type="button" class="btn btn-danger" ng-click="exportWidgetsToPdf()" title="Export Tables to PDF.">
-            <span class="glyphicon glyphicon-download" aria-hidden="true"></span> PDF
+        <button style="float: right; margin-right: 5px;" type="button" class="btn btn-danger" ng-click="exportWidgetsToPdf()" title="Export Widgets to PDF." ng-disabled="downloadingPDF">
+            <i class="fa fa-spinner fa-spin" ng-show="downloadingPDF"></i>
+            <span class="fa fa-download" aria-hidden="true" ng-show="!downloadingPDF"></span> PDF
         </button>
-        <button style="float: right; margin-right: 5px;" type="button" class="btn btn-success" ng-click="exportWidgets()" title="Export Tables to XLS.">
-            <span class="glyphicon glyphicon-download" aria-hidden="true"></span> XLS
+        <button style="float: right; margin-right: 5px;" type="button" class="btn btn-success" ng-click="exportWidgets()" title="Export Widgets to XLS." ng-disabled="downloadingXLS">
+            <i class="fa fa-spinner fa-spin" ng-show="downloadingXLS"></i>
+            <i class="fa fa-download" aria-hidden="true" ng-show="!downloadingXLS"></i> XLS
         </button>
-        <span title="{{isFavorite ? 'Remove from favorites' : 'Add to favorites'}}" class="pull-left fa dashboard-favorite-icon" 
+        <span title="{{isFavorite ? 'Remove from favorites' : 'Add to favorites'}}" class="pull-left fa dashboard-favorite-icon"
               ng-click="isFavorite = !isFavorite; toggleFavorite(isFavorite)" ng-class="{'fa-star' : isFavorite, 'fa-star-o': !isFavorite}"></span>
     </h2>
 

--- a/redash/devspark/custom_handlers/excel_formatter.py
+++ b/redash/devspark/custom_handlers/excel_formatter.py
@@ -106,7 +106,7 @@ def generate_first_page(workbook, filters, reports):
     # Filters Applied
     colIdx = 2
     rowIdx = 7
-    for row in filters['data']:
+    for row in filters.get('data', []):
         for column in filters['columnNames']:
             worksheet.write(rowIdx, colIdx, row[column], font)
             colIdx += 1
@@ -114,8 +114,8 @@ def generate_first_page(workbook, filters, reports):
         colIdx = 2
 
 @app.route('/api/dashboard/generate_excel', methods=['POST'])
-def get_tasks():
-    app.logger.debug(request.json)
+def generate_excel():
+    #app.logger.debug(request.json)
 
     data = request.json
 
@@ -123,7 +123,7 @@ def get_tasks():
         workbook = xlsxwriter.Workbook(tmp_flo.name)
 
         # First page of XLS
-        generate_first_page(workbook, data['filters'], data['reports'])
+        generate_first_page(workbook, data.get('filters', {}), data['reports'])
 
         # Add a bold format to use to highlight cells.
         format1 = workbook.add_format({
@@ -166,9 +166,9 @@ def get_tasks():
                 rowIdx += 1
             rowIdx += 1
 
-             # Adds autofilter on all columns if 'option.filter' is defined as true
+            # Adds autofilter on all columns if 'option.filter' is defined as true
             if _filter:
-                worksheet.autofilter(rowIdx, 0, len(sheet['data']), len(sheet['option']['columnNames']) - 1)
+                worksheet.autofilter(rowIdx, 0, rowIdx + len(sheet['data']) + 1, len(sheet['option']['columnNames']) - 1)
 
             # Defines the header
             for column in sheet['option']['columnNames']:


### PR DESCRIPTION
- https://trello.com/c/STuN0s8v/186-issue-to-export-xls-too-large-listings-07-export-mg-details-leads: for this bug the timeouts were increased on prod.
- Added spinner and blocked export buttons when user is downloading a file
- Minor changes on ui , changed export icons to use fa icons
- Added capability to export without showing hidden columns.
- Added fix to excel handler so BE does not fail if user exports dashboards without filters.
- Updated autofilters on xls generator because they were filtering empty columns (offset of columns that needed autofilter)